### PR TITLE
Added OpenDNSSEC project: OpenDNSSEC 2.1.4 + SoftHSM 2.5.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,7 +106,9 @@ for anyone interested, especially those running validating resolvers.</p>
 <tr><td><a target="_blank" href="https://www.knot-dns.cz/">kdig</a></td><td></td><td>cli: advanced lookups including DoT (part of Knot DNS)</td></tr>
 <tr><td><a target="_blank" href="https://www.nlnetlabs.nl/projects/ldns/">ldns</a></td><td>1.7.0</td><td>cli: library that includes a lookup tool (drill) that provides even more information than dig</td></tr>
 <tr><td><a target="_blank" href="https://github.com/google/namebench">Namebench</a></td><td>2.0</td><td>cli: benchmark nameserver performance</td></tr>
+<tr><td><a target="_blank" href="https://www.opendnssec.org/">OpenDNSSEC</a></td><td>2.1.4</td><td>cli: policy-based zone signer with PKCS#11 interface</td></tr>
 <tr><td><a target="_blank" href="https://www.dns-oarc.net/tools/packetq">PacketQ</a></td><td>1.4.1</td><td>cli: run sql queries agaist pcap files</td></tr>
+<tr><td><a target="_blank" href="https://www.opendnssec.org/softhsm/">SoftHSM</a></td><td>2.5.0</td><td>cli: optional companion for OpenDNSSEC. Cryptographic store with PKCS#11 interface</td></tr>
 <tr><td><a target="_blank" href="https://trans-trust.verisignlabs.com/">The Transitive Trust and DNS Dependency Graph Portal</a></td><td></td><td>web: graphs of transitive trust and dependencies</td></tr>
 <tr><td><a target="_blank" href="http://unbound.net/">unbound-host</a></td><td></td><td>cli: lookup (part of unbound)</td></tr>
 <tr><td><a target="_blank" href="http://zonemaster.fr/">Zonemaster</a></td><td>2018.2.2</td><td>cli+web: zone delegation quality checker</td></tr>


### PR DESCRIPTION
Hi, these tools, OpenDNSSEC and SoftHSM - (from OpenDNSSEC project - https://www.opendnssec.org/) - are different from the others I've added previously (dHSM, from https://niclabs.cl)

Thanks in advance.

Regards,
Pablo.