### PR TITLE
Update mens.de link to "Alternative DNS Servers".

### DIFF
--- a/index.html
+++ b/index.html
@@ -249,7 +249,7 @@ limited record types (no dnssec), secondary (dnssec)</td></tr>
         <td>Compilation of blogged DNS links from Jan-Piet Mens</td>
       </tr>
       <tr>
-        <td><a target="_blank" href="http://mens.de/:/altdnsbook">Alternative DNS Servers (Free)</a></td>
+        <td><a target="_blank" href="https://mens.de/:/altdnsbook">Alternative DNS Servers (Free)</a></td>
         <td>Book written by Jan-Piet Mens</td>
       </tr>
 


### PR DESCRIPTION
Update URL in "Alternative DNS Servers" link from http to https as the http link no longer seems to work.