### PR TITLE
Misc version updates June 18th, 2024

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,8 +58,8 @@ for anyone interested, especially those running validating resolvers.</p>
 <tr><td><a target="_blank" href="http://www.thekelleys.org.uk/dnsmasq/doc.html">dnsmasq</a></td><td>2.86</td><td>filtering proxy with authoritative abilities</td></tr>
 <tr><td><a target="_blank" href="https://github.com/commonshost/dohnut">Dohnut</a></td><td>4.11.0</td><td>DNS to DoH proxy, load balancer, query fuzzer</td></tr>
 <tr><td><a target="_blank" href="http://gdnsd.org/">gdnsd</a></td><td>3.8.0</td><td>authoritative</td></tr>
-<tr><td><a target="_blank" href="https://www.knot-dns.cz/">Knot DNS</a></td><td>3.1.9</td><td>authoritative</td></tr>
-<tr><td><a target="_blank" href="https://www.knot-resolver.cz/">Knot Resolver</a></td><td>5.5.1</td><td>validating resolver</td></tr>
+<tr><td><a target="_blank" href="https://www.knot-dns.cz/">Knot DNS</a></td><td>3.2.0</td><td>authoritative</td></tr>
+<tr><td><a target="_blank" href="https://www.knot-resolver.cz/">Knot Resolver</a></td><td>5.5.2</td><td>validating resolver</td></tr>
 <tr><td><a target="_blank" href="http://www.maradns.org/">MaraDNS</a></td><td>3.5.0022</td><td>authoritative (now includes the Deadwood resolver)</td></tr>
 <tr><td><a target="_blank" href="https://www.nlnetlabs.nl/projects/nsd/">NSD</a></td><td>4.6.0</td><td>authoritative</td></tr>
 <tr><td><a target="_blank" href="http://www.nxfilter.org/">NxFilter</a></td><td>4.6.3.1</td><td>filtering proxy</td></tr>
@@ -106,11 +106,11 @@ for anyone interested, especially those running validating resolvers.</p>
 <tr><td><a target="_blank" href="https://www.dns-oarc.net/tools/dsc">dsc</a></td><td>2.13.1</td><td>cli: DNS Statistics Collector</td></tr>
 <tr><td><a target="_blank" href="https://www.dns-oarc.net/tools/dsc">dsp</a></td><td>2.0.1</td><td>cli: DNS Statistics Presenter (companion for dsc collector)</td></tr>
 <tr><td><a target="_blank" href="https://github.com/DNS-OARC/flamethrower">flamethrower</a></td><td>0.11.0</td><td>cli: benchmark nameserver performance</td></tr>
-<tr><td><a target="_blank" href="https://getdnsapi.net/">getdnsapi</a></td><td>1.7.1</td><td>new api to use dns</td></tr>
+<tr><td><a target="_blank" href="https://getdnsapi.net/">getdnsapi</a></td><td>1.7.2</td><td>new api to use dns</td></tr>
 <tr><td><a target="_blank" href="https://dns.google/">Google Public DNS</a></td><td></td><td>web: web based resolver</td></tr>
 <tr><td><a target="_blank" href="http://intodns.com/">intoDNS</a></td><td></td><td>web: provides lots of info about a domain (some requires own interpretation)</td></tr>
 <tr><td><a target="_blank" href="https://www.knot-dns.cz/">kdig</a></td><td></td><td>cli: advanced lookups including DoT &amp; DoH (part of Knot DNS)</td></tr>
-<tr><td><a target="_blank" href="https://www.nlnetlabs.nl/projects/ldns/">ldns</a></td><td>1.8.2</td><td>cli: library that includes a lookup tool (drill) that provides even more information than dig</td></tr>
+<tr><td><a target="_blank" href="https://www.nlnetlabs.nl/projects/ldns/">ldns</a></td><td>1.8.3</td><td>cli: library that includes a lookup tool (drill) that provides even more information than dig</td></tr>
 <tr><td><a target="_blank" href="https://github.com/google/namebench">Namebench</a></td><td>2.0</td><td>cli: benchmark nameserver performance</td></tr>
 <tr><td><a target="_blank" href="https://dotat.at/prog/nsdiff/">nsdiff</a></td><td></td><td>cli:
 nsdiff/nspatch/nsvi zone diff/update tool</td></tr>


### PR DESCRIPTION
Misc version updates June 18th, 2024. Includes:

Knot DNS, Knot Resolver, NSD, Nxfilter, systemd-resolved, Technitium DNS server, Unbound, YADIFA, DNSDiag, dsc, and dsp (discontinued), Zonemaster.