### PR TITLE
Add new tool: IBDNS 0.3.4 [Intentionally Broken DNS Server] - Released by Afnic.

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,6 +108,7 @@ for anyone interested, especially those running validating resolvers.</p>
 <tr><td><a target="_blank" href="https://github.com/DNS-OARC/flamethrower">flamethrower</a></td><td>0.11.0</td><td>cli: benchmark nameserver performance</td></tr>
 <tr><td><a target="_blank" href="https://getdnsapi.net/">getdnsapi</a></td><td>1.7.3</td><td>new api to use dns</td></tr>
 <tr><td><a target="_blank" href="https://dns.google/">Google Public DNS</a></td><td></td><td>web: web based resolver</td></tr>
+<tr><td><a target="_blank" href="https://gitlab.rd.nic.fr/dns-testing-tools/ibdns">IBDNS</a></td><td>0.3.4</td><td>server: Intentionally Broken DNS server</td></tr>
 <tr><td><a target="_blank" href="http://intodns.com/">intoDNS</a></td><td></td><td>web: provides lots of info about a domain (some requires own interpretation)</td></tr>
 <tr><td><a target="_blank" href="https://www.knot-dns.cz/">kdig</a></td><td></td><td>cli: advanced lookups including DoT &amp; DoH (part of Knot DNS)</td></tr>
 <tr><td><a target="_blank" href="https://www.nlnetlabs.nl/projects/ldns/">ldns</a></td><td>1.8.3</td><td>cli: library that includes a lookup tool (drill) that provides even more information than dig</td></tr>


### PR DESCRIPTION
Add new tool: IBDNS 0.3.4 [Intentionally Broken DNS Server] - Released by Afnic.
