### PR TITLE
Updates for multiple PowerDNS products.

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@ for anyone interested, especially those running validating resolvers.</p>
 <tr><td><a target="_blank" href="https://cr.yp.to/djbdns.html">djbdns</a></td><td>1.05</td><td>authoritative (limited record types supported) and non-validating resolver using distinct programs</td></tr>
 <tr><td><a target="_blank" href="http://dnrd.sourceforge.net/">DNRD</a></td><td>2.20.3</td><td>proxy</td></tr>
 <tr><td><a target="_blank" href="https://github.com/DNSCrypt/dnscrypt-proxy">dnscrypt-proxy</a></td><td>2.1.15</td><td>proxy/forwarder</td></tr>
-<tr><td><a target="_blank" href="https://dnsdist.org/">dnsdist</a></td><td>2.0.6</td><td>load balancer, DoT (since 1.3.0), DoH (since 1.4.0), DoH3 (since 1.9.0), DoQ (since 1.9.0), dnscrypt</td></tr>
+<tr><td><a target="_blank" href="https://dnsdist.org/">dnsdist</a></td><td>2.0.7</td><td>load balancer, DoT (since 1.3.0), DoH (since 1.4.0), DoH3 (since 1.9.0), DoQ (since 1.9.0), dnscrypt</td></tr>
 <tr><td><a target="_blank" href="http://www.thekelleys.org.uk/dnsmasq/doc.html">dnsmasq</a></td><td>2.92rel2</td><td>filtering proxy with authoritative abilities</td></tr>
 <tr><td><a target="_blank" href="https://github.com/commonshost/dohnut">Dohnut</a></td><td>4.11.0</td><td>DNS to DoH proxy, load balancer, query fuzzer</td></tr>
 <tr><td><a target="_blank" href="http://gdnsd.org/">gdnsd</a></td><td>3.8.3</td><td>authoritative</td></tr>
@@ -65,8 +65,8 @@ for anyone interested, especially those running validating resolvers.</p>
 <tr><td><a target="_blank" href="http://www.nxfilter.org/">NxFilter</a></td><td>4.7.4.9</td><td>filtering proxy</td></tr>
 <tr><td><a target="_blank" href="http://members.home.nl/p.a.rombouts/pdnsd/">pdnsd</a></td><td>1.2.9a-par</td><td>proxy</td></tr>
 <tr><td><a target="_blank" href="http://posadis.sourceforge.net/posadis">Posadis</a></td><td>0.60.6</td><td>authoritative and resolver in one - Site page link broken - <a target="_blank" href="https://sourceforge.net/projects/posadis/files/posadis/">Sourceforge.net files here</a><br>Web Archive links: <a target="_blank" href="https://web.archive.org/web/20071224204002/http://posadis.sourceforge.net/download">Site page here</a> - <a target="_blank" href="https://web.archive.org/web/20070717124836/http://www.posadis.org/files/">Original Files [Posadis site]</a></td></tr>
-<tr><td><a target="_blank" href="https://www.powerdns.com/auth.html">PowerDNS Authoritative Server</a></td><td>5.1.1</td><td>authoritative</td></tr>
-<tr><td><a target="_blank" href="https://www.powerdns.com/recursor.html">PowerDNS Recursor</a></td><td>5.4.2</td><td>resolver</td></tr>
+<tr><td><a target="_blank" href="https://www.powerdns.com/auth.html">PowerDNS Authoritative Server</a></td><td>5.1.2</td><td>authoritative</td></tr>
+<tr><td><a target="_blank" href="https://www.powerdns.com/recursor.html">PowerDNS Recursor</a></td><td>5.4.3</td><td>resolver</td></tr>
 <tr><td><a target="_blank" href="http://posadis.sourceforge.net/sans">SANS</a></td><td>1.0.1</td><td>authoritative - Broken link.<br>Web Archive link: <a target="_blank" href="https://web.archive.org/web/20071215172058/http://posadis.sourceforge.net/sans">Site page here</a> - <a target="_blank" href="https://sourceforge.net/projects/posadis/files/sans/">Original Files [sourceforge.net]</a></td></tr>
 <tr><td><a target="_blank" href="http://simpledns.com/">Simple DNS Plus</a></td><td>9.1(116)</td><td>authoritative and resolver all in one</td></tr>
 <tr><td><a target="_blank" href="https://dnsprivacy.org/wiki/display/DP/DNS+Privacy+Daemon+-+Stubby">stubby</a></td><td>0.4.3</td><td>proxy</td></tr>


### PR DESCRIPTION
- Update for PowerDNS Authoritative Server 5.1.2.
- Update for PowerDNS Recursor 5.4.2.
- Update for PowerDNS DNSdist 2.0.7.