### PR TITLE
Add DNS Checker to Tools

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,6 +93,7 @@ for anyone interested, especially those running validating resolvers.</p>
 <tr><td><a target="_blank" href="https://github.com/niclabs/dhsm-signer/">dHSM zone signer</a></td><td></td><td>cli: Zone signer companion for dHSM by using PKCS11</td></tr>
 <tr><td><a target="_blank" href="https://www.isc.org/downloads/bind/">dig</a></td><td></td><td>cli: lookup (part of BIND)</td></tr>
 <tr><td><a target="_blank" href="http://www.zonecut.net/dns/">DNSBajaj (DNS By Eye)</a></td><td>0.9.6</td><td>web: check the delegation of your domain by using graphs of dependencies<br>download link broken.&nbsp<a target="_blank" href="http://web.archive.org/web/20081219233618/http://ftp.linuxarkivet.se:80/pub/dnsbajaj/">original sources here</a></td></tr>
+<tr><td><a target="_blank" href="https://dnschkr.com/">DNS Checker</a></td><td></td><td>web: scored lookup report over A/AAAA/MX/NS/SOA/TXT/CNAME/CAA, covering delegation and glue, DNSSEC chain, TTL strategy, per-nameserver response times and a resolution waterfall</td></tr>
 <tr><td><a target="_blank" href="https://github.com/dmachard/go-dnscollector">DNS-collector</a></td><td>2.2.3</td><td>cli: high speed passive DNS stats collector.</td></tr>
 <tr><td><a target="_blank" href="https://dnsdiag.org/">DNSDiag</a></td><td>2.9.3</td><td>cli: diagnostics and performance measurement</td></tr>
 <tr><td><a target="_blank" href="https://github.com/DNS-OARC/dnsperf">dnsperf/resperf</a></td><td>2.14.0</td><td>cli: benchmark nameserver performance</td></tr>


### PR DESCRIPTION
I run DNS Checker (https://dnschkr.com/), a hosted DNS lookup and diagnostics site, and I would like to add it to the Tools table.

It gives a scored report for a domain across A/AAAA/MX/NS/SOA/TXT/CNAME/CAA, covering delegation and glue, the DNSSEC chain, TTL strategy, per-nameserver response times and a resolution waterfall.

I have slotted it alphabetically between DNSBajaj and DNS-collector, and left the version column blank to match the other hosted web entries such as intoDNS and DNSstuff, since there is no downloadable release to pin a number to.

Happy to trim the description or move the row if you would prefer it shorter.