### PR TITLE
Update DNS software versions - Add coredns-gslb - fix links.

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,28 +52,28 @@ for anyone interested, especially those running validating resolvers.</p>
 <tr><td><a target="_blank" href="https://www.cisco.com/c/en/us/products/cloud-systems-management/prime-network-registrar/">Cisco Prime Network Registrar DNS</a></td><td>11.4</td><td>authoritative and validating resolver</td></tr>
 <tr><td><a target="_blank" href="https://coredns.io/">CoreDNS</a></td><td>1.14.6</td><td>DNS server written in Go, with service discovery and chaining plugins</td></tr>
 <tr><td><a target="_blank" href="https://cr.yp.to/djbdns.html">djbdns</a></td><td>1.05</td><td>authoritative (limited record types supported) and non-validating resolver using distinct programs</td></tr>
-<tr><td><a target="_blank" href="http://dnrd.sourceforge.net/">DNRD</a></td><td>2.20.3</td><td>proxy</td></tr>
+<tr><td><a target="_blank" href="https://dnrd.sourceforge.net/">DNRD</a></td><td>2.20.3</td><td>proxy</td></tr>
 <tr><td><a target="_blank" href="https://github.com/DNSCrypt/dnscrypt-proxy">dnscrypt-proxy</a></td><td>2.1.18</td><td>proxy/forwarder</td></tr>
 <tr><td><a target="_blank" href="https://dnsdist.org/">dnsdist</a></td><td>2.1.1</td><td>load balancer, DoT (since 1.3.0), DoH (since 1.4.0), DoH3 (since 1.9.0), DoQ (since 1.9.0), dnscrypt</td></tr>
-<tr><td><a target="_blank" href="http://www.thekelleys.org.uk/dnsmasq/doc.html">dnsmasq</a></td><td>2.93</td><td>filtering proxy with authoritative abilities</td></tr>
+<tr><td><a target="_blank" href="https://thekelleys.org.uk/dnsmasq/doc.html">dnsmasq</a></td><td>2.93</td><td>filtering proxy with authoritative abilities</td></tr>
 <tr><td><a target="_blank" href="https://github.com/commonshost/dohnut">Dohnut</a></td><td>4.11.0</td><td>DNS to DoH proxy, load balancer, query fuzzer</td></tr>
-<tr><td><a target="_blank" href="http://gdnsd.org/">gdnsd</a></td><td>3.8.3</td><td>authoritative</td></tr>
+<tr><td><a target="_blank" href="https://gdnsd.org/">gdnsd</a></td><td>3.8.3</td><td>authoritative</td></tr>
 <tr><td><a target="_blank" href="https://www.knot-dns.cz/">Knot DNS</a></td><td>3.5.6</td><td>authoritative</td></tr>
 <tr><td><a target="_blank" href="https://www.knot-resolver.cz/">Knot Resolver</a></td><td>6.4.2</td><td>validating resolver</td></tr>
-<tr><td><a target="_blank" href="http://www.maradns.org/">MaraDNS</a></td><td>3.5.0038</td><td>authoritative (now includes the Deadwood resolver)</td></tr>
+<tr><td><a target="_blank" href="https://www.maradns.org/">MaraDNS</a></td><td>3.5.0038</td><td>authoritative (now includes the Deadwood resolver)</td></tr>
 <tr><td><a target="_blank" href="https://www.nlnetlabs.nl/projects/nsd/">NSD</a></td><td>4.15.0</td><td>authoritative</td></tr>
-<tr><td><a target="_blank" href="http://www.nxfilter.org/">NxFilter</a></td><td>4.7.5.3</td><td>filtering proxy</td></tr>
+<tr><td><a target="_blank" href="https://nxfilter.org/">NxFilter</a></td><td>4.7.5.3</td><td>filtering proxy</td></tr>
 <tr><td><a target="_blank" href="http://members.home.nl/p.a.rombouts/pdnsd/">pdnsd</a></td><td>1.2.9a-par</td><td>proxy - Broken link.<br>Web Archive link: <a target=¨_blank" href="https://web.archive.org/web/20201203080556/http://members.home.nl/p.a.rombouts/pdnsd/">Site page here</a> - <a target="_blank" href="https://web.archive.org/web/20200323100335/http://members.home.nl/p.a.rombouts/pdnsd/releases/">Original Files [pdnsd site]</a></td></tr>
 <tr><td><a target="_blank" href="http://posadis.sourceforge.net/posadis">Posadis</a></td><td>0.60.6</td><td>authoritative and resolver in one - Site page link broken - <a target="_blank" href="https://sourceforge.net/projects/posadis/files/posadis/">Sourceforge.net files here</a><br>Web Archive links: <a target="_blank" href="https://web.archive.org/web/20071224204002/http://posadis.sourceforge.net/download">Site page here</a> - <a target="_blank" href="https://web.archive.org/web/20070717124836/http://www.posadis.org/files/">Original Files [Posadis site]</a></td></tr>
 <tr><td><a target="_blank" href="https://www.powerdns.com/auth.html">PowerDNS Authoritative Server</a></td><td>5.1.4</td><td>authoritative</td></tr>
 <tr><td><a target="_blank" href="https://www.powerdns.com/recursor.html">PowerDNS Recursor</a></td><td>5.4.5</td><td>resolver</td></tr>
 <tr><td><a target="_blank" href="http://posadis.sourceforge.net/sans">SANS</a></td><td>1.0.1</td><td>authoritative - Broken link.<br>Web Archive link: <a target="_blank" href="https://web.archive.org/web/20071215172058/http://posadis.sourceforge.net/sans">Site page here</a> - <a target="_blank" href="https://sourceforge.net/projects/posadis/files/sans/">Original Files [sourceforge.net]</a></td></tr>
-<tr><td><a target="_blank" href="http://simpledns.com/">Simple DNS Plus</a></td><td>9.1(117)</td><td>authoritative and resolver all in one</td></tr>
+<tr><td><a target="_blank" href="https//simpledns.plus/">Simple DNS Plus</a></td><td>9.1(117)</td><td>authoritative and resolver all in one</td></tr>
 <tr><td><a target="_blank" href="https://dnsprivacy.org/wiki/display/DP/DNS+Privacy+Daemon+-+Stubby">stubby</a></td><td>0.4.3</td><td>proxy</td></tr>
 <tr><td><a target="_blank" href="https://github.com/systemd/systemd">systemd-resolved</a></td><td>261.2</td><td>optionally validating resolver (part of systemd), also supports DoT, LLMNR and mDNS</td></tr>
 <tr><td><a target="_blank" href="https://technitium.com/dns/">Technitium DNS Server</a></td><td>15.4</td><td>resolver and proxy supporting optional forwarding via DoH (standard or "JSON") or DoT</td></tr>
 <tr><td><a target="_blank" href="https://unbound.net/">Unbound</a></td><td>1.26.0</td><td>validating resolver, DoH, DoT, dnscrypt</td></tr>
-<tr><td><a target="_blank" href="http://www.yadifa.eu/">YADIFA</a></td><td>3.0.3</td><td>authoritative</td></tr>
+<tr><td><a target="_blank" href="https://yadifa.eu/">YADIFA</a></td><td>3.0.3</td><td>authoritative</td></tr>
 </tbody>
 </table>
 

--- a/index.html
+++ b/index.html
@@ -51,6 +51,7 @@ for anyone interested, especially those running validating resolvers.</p>
 <tr><td><a target="_blank" href="https://www.isc.org/downloads/bind/">BIND</a></td><td>9.20.26</td><td>authoritative and validating resolver in one</td></tr>
 <tr><td><a target="_blank" href="https://www.cisco.com/c/en/us/products/cloud-systems-management/prime-network-registrar/">Cisco Prime Network Registrar DNS</a></td><td>11.4</td><td>authoritative and validating resolver</td></tr>
 <tr><td><a target="_blank" href="https://coredns.io/">CoreDNS</a></td><td>1.14.6</td><td>DNS server written in Go, with service discovery and chaining plugins</td></tr>
+<tr><td><a target="_blank" href="https://github.com/dmachard/coredns-gslb">CoreDNS-GSLB</a></td><td>0.22.0</td><td>plugin that provides Global Server Load Balancing functionality in <a target="_blank" href="https://coredns.io/">CoreDNS.</a></td></tr>
 <tr><td><a target="_blank" href="https://cr.yp.to/djbdns.html">djbdns</a></td><td>1.05</td><td>authoritative (limited record types supported) and non-validating resolver using distinct programs</td></tr>
 <tr><td><a target="_blank" href="https://dnrd.sourceforge.net/">DNRD</a></td><td>2.20.3</td><td>proxy</td></tr>
 <tr><td><a target="_blank" href="https://github.com/DNSCrypt/dnscrypt-proxy">dnscrypt-proxy</a></td><td>2.1.18</td><td>proxy/forwarder</td></tr>

--- a/index.html
+++ b/index.html
@@ -49,30 +49,30 @@ for anyone interested, especially those running validating resolvers.</p>
 </thead>
 <tbody>
 <tr><td><a target="_blank" href="https://www.isc.org/downloads/bind/">BIND</a></td><td>9.20.26</td><td>authoritative and validating resolver in one</td></tr>
-<tr><td><a target="_blank" href="https://www.cisco.com/c/en/us/products/cloud-systems-management/prime-network-registrar/">Cisco Prime Network Registrar DNS</a></td><td>11.2</td><td>authoritative and validating resolver</td></tr>
-<tr><td><a target="_blank" href="https://coredns.io/">CoreDNS</a></td><td>1.14.2</td><td>DNS server written in Go, with service discovery and chaining plugins</td></tr>
+<tr><td><a target="_blank" href="https://www.cisco.com/c/en/us/products/cloud-systems-management/prime-network-registrar/">Cisco Prime Network Registrar DNS</a></td><td>11.4</td><td>authoritative and validating resolver</td></tr>
+<tr><td><a target="_blank" href="https://coredns.io/">CoreDNS</a></td><td>1.14.6</td><td>DNS server written in Go, with service discovery and chaining plugins</td></tr>
 <tr><td><a target="_blank" href="https://cr.yp.to/djbdns.html">djbdns</a></td><td>1.05</td><td>authoritative (limited record types supported) and non-validating resolver using distinct programs</td></tr>
 <tr><td><a target="_blank" href="http://dnrd.sourceforge.net/">DNRD</a></td><td>2.20.3</td><td>proxy</td></tr>
-<tr><td><a target="_blank" href="https://github.com/DNSCrypt/dnscrypt-proxy">dnscrypt-proxy</a></td><td>2.1.15</td><td>proxy/forwarder</td></tr>
-<tr><td><a target="_blank" href="https://dnsdist.org/">dnsdist</a></td><td>2.1.0</td><td>load balancer, DoT (since 1.3.0), DoH (since 1.4.0), DoH3 (since 1.9.0), DoQ (since 1.9.0), dnscrypt</td></tr>
-<tr><td><a target="_blank" href="http://www.thekelleys.org.uk/dnsmasq/doc.html">dnsmasq</a></td><td>2.92rel2</td><td>filtering proxy with authoritative abilities</td></tr>
+<tr><td><a target="_blank" href="https://github.com/DNSCrypt/dnscrypt-proxy">dnscrypt-proxy</a></td><td>2.1.18</td><td>proxy/forwarder</td></tr>
+<tr><td><a target="_blank" href="https://dnsdist.org/">dnsdist</a></td><td>2.1.1</td><td>load balancer, DoT (since 1.3.0), DoH (since 1.4.0), DoH3 (since 1.9.0), DoQ (since 1.9.0), dnscrypt</td></tr>
+<tr><td><a target="_blank" href="http://www.thekelleys.org.uk/dnsmasq/doc.html">dnsmasq</a></td><td>2.93</td><td>filtering proxy with authoritative abilities</td></tr>
 <tr><td><a target="_blank" href="https://github.com/commonshost/dohnut">Dohnut</a></td><td>4.11.0</td><td>DNS to DoH proxy, load balancer, query fuzzer</td></tr>
 <tr><td><a target="_blank" href="http://gdnsd.org/">gdnsd</a></td><td>3.8.3</td><td>authoritative</td></tr>
-<tr><td><a target="_blank" href="https://www.knot-dns.cz/">Knot DNS</a></td><td>3.5.4</td><td>authoritative</td></tr>
-<tr><td><a target="_blank" href="https://www.knot-resolver.cz/">Knot Resolver</a></td><td>6.3.0</td><td>validating resolver</td></tr>
-<tr><td><a target="_blank" href="http://www.maradns.org/">MaraDNS</a></td><td>3.5.0036</td><td>authoritative (now includes the Deadwood resolver)</td></tr>
-<tr><td><a target="_blank" href="https://www.nlnetlabs.nl/projects/nsd/">NSD</a></td><td>4.14.2</td><td>authoritative</td></tr>
-<tr><td><a target="_blank" href="http://www.nxfilter.org/">NxFilter</a></td><td>4.7.4.9</td><td>filtering proxy</td></tr>
-<tr><td><a target="_blank" href="http://members.home.nl/p.a.rombouts/pdnsd/">pdnsd</a></td><td>1.2.9a-par</td><td>proxy</td></tr>
+<tr><td><a target="_blank" href="https://www.knot-dns.cz/">Knot DNS</a></td><td>3.5.6</td><td>authoritative</td></tr>
+<tr><td><a target="_blank" href="https://www.knot-resolver.cz/">Knot Resolver</a></td><td>6.4.2</td><td>validating resolver</td></tr>
+<tr><td><a target="_blank" href="http://www.maradns.org/">MaraDNS</a></td><td>3.5.0038</td><td>authoritative (now includes the Deadwood resolver)</td></tr>
+<tr><td><a target="_blank" href="https://www.nlnetlabs.nl/projects/nsd/">NSD</a></td><td>4.15.0</td><td>authoritative</td></tr>
+<tr><td><a target="_blank" href="http://www.nxfilter.org/">NxFilter</a></td><td>4.7.5.3</td><td>filtering proxy</td></tr>
+<tr><td><a target="_blank" href="http://members.home.nl/p.a.rombouts/pdnsd/">pdnsd</a></td><td>1.2.9a-par</td><td>proxy - Broken link.<br>Web Archive link: <a target=¨_blank" href="https://web.archive.org/web/20201203080556/http://members.home.nl/p.a.rombouts/pdnsd/">Site page here</a> - <a target="_blank" href="https://web.archive.org/web/20200323100335/http://members.home.nl/p.a.rombouts/pdnsd/releases/">Original Files [pdnsd site]</a></td></tr>
 <tr><td><a target="_blank" href="http://posadis.sourceforge.net/posadis">Posadis</a></td><td>0.60.6</td><td>authoritative and resolver in one - Site page link broken - <a target="_blank" href="https://sourceforge.net/projects/posadis/files/posadis/">Sourceforge.net files here</a><br>Web Archive links: <a target="_blank" href="https://web.archive.org/web/20071224204002/http://posadis.sourceforge.net/download">Site page here</a> - <a target="_blank" href="https://web.archive.org/web/20070717124836/http://www.posadis.org/files/">Original Files [Posadis site]</a></td></tr>
-<tr><td><a target="_blank" href="https://www.powerdns.com/auth.html">PowerDNS Authoritative Server</a></td><td>5.1.3</td><td>authoritative</td></tr>
-<tr><td><a target="_blank" href="https://www.powerdns.com/recursor.html">PowerDNS Recursor</a></td><td>5.4.3</td><td>resolver</td></tr>
+<tr><td><a target="_blank" href="https://www.powerdns.com/auth.html">PowerDNS Authoritative Server</a></td><td>5.1.4</td><td>authoritative</td></tr>
+<tr><td><a target="_blank" href="https://www.powerdns.com/recursor.html">PowerDNS Recursor</a></td><td>5.4.5</td><td>resolver</td></tr>
 <tr><td><a target="_blank" href="http://posadis.sourceforge.net/sans">SANS</a></td><td>1.0.1</td><td>authoritative - Broken link.<br>Web Archive link: <a target="_blank" href="https://web.archive.org/web/20071215172058/http://posadis.sourceforge.net/sans">Site page here</a> - <a target="_blank" href="https://sourceforge.net/projects/posadis/files/sans/">Original Files [sourceforge.net]</a></td></tr>
-<tr><td><a target="_blank" href="http://simpledns.com/">Simple DNS Plus</a></td><td>9.1(116)</td><td>authoritative and resolver all in one</td></tr>
+<tr><td><a target="_blank" href="http://simpledns.com/">Simple DNS Plus</a></td><td>9.1(117)</td><td>authoritative and resolver all in one</td></tr>
 <tr><td><a target="_blank" href="https://dnsprivacy.org/wiki/display/DP/DNS+Privacy+Daemon+-+Stubby">stubby</a></td><td>0.4.3</td><td>proxy</td></tr>
-<tr><td><a target="_blank" href="https://github.com/systemd/systemd">systemd-resolved</a></td><td>260.1</td><td>optionally validating resolver (part of systemd), also supports DoT, LLMNR and mDNS</td></tr>
-<tr><td><a target="_blank" href="https://technitium.com/dns/">Technitium DNS Server</a></td><td>15.2</td><td>resolver and proxy supporting optional forwarding via DoH (standard or "JSON") or DoT</td></tr>
-<tr><td><a target="_blank" href="https://unbound.net/">Unbound</a></td><td>1.25.0</td><td>validating resolver, DoH, DoT, dnscrypt</td></tr>
+<tr><td><a target="_blank" href="https://github.com/systemd/systemd">systemd-resolved</a></td><td>261.2</td><td>optionally validating resolver (part of systemd), also supports DoT, LLMNR and mDNS</td></tr>
+<tr><td><a target="_blank" href="https://technitium.com/dns/">Technitium DNS Server</a></td><td>15.4</td><td>resolver and proxy supporting optional forwarding via DoH (standard or "JSON") or DoT</td></tr>
+<tr><td><a target="_blank" href="https://unbound.net/">Unbound</a></td><td>1.26.0</td><td>validating resolver, DoH, DoT, dnscrypt</td></tr>
 <tr><td><a target="_blank" href="http://www.yadifa.eu/">YADIFA</a></td><td>3.0.3</td><td>authoritative</td></tr>
 </tbody>
 </table>


### PR DESCRIPTION
Update DNS software versions. Broken links fix. https replaces old http links. Add coredns-gslb plugin for coreDNS.